### PR TITLE
Ordinal interactions

### DIFF
--- a/lightfm/_lightfm_fast.pyx.template
+++ b/lightfm/_lightfm_fast.pyx.template
@@ -181,6 +181,18 @@ cdef class CSRMatrix:
 
         return self.indptr[row + 1]
 
+    cdef flt get_entry(self, int row, int col) nogil:
+        """
+        Return the entry at the coordinate
+        """
+        start_idx = self.get_row_start(row)
+        stop_idx = self.get_row_end(row)
+
+        for i in range(start_idx, stop_idx):
+          if self.indices[i] == col:
+            return self.data[i]
+        return 0.0
+
 
 cdef class FastLightFM:
     """
@@ -794,7 +806,8 @@ def fit_warp(CSRMatrix item_features,
              double item_alpha,
              double user_alpha,
              int num_threads,
-             random_state):
+             random_state,
+             bint ordered=False):
     """
     Fit the model using the WARP loss.
     """
@@ -802,6 +815,7 @@ def fit_warp(CSRMatrix item_features,
     cdef int i, no_examples, user_id, positive_item_id, gamma
     cdef int negative_item_id, sampled, row
     cdef double positive_prediction, negative_prediction
+    cdef flt positive_true, negative_true
     cdef double loss, MAX_LOSS
     cdef flt weight
     cdef flt *user_repr
@@ -852,6 +866,8 @@ def fit_warp(CSRMatrix item_features,
                                                                pos_it_repr,
                                                                lightfm.no_components)
 
+            positive_true = interactions.get_entry(user_id, positive_item_id)
+
             sampled = 0
 
             while sampled < lightfm.max_sampled:
@@ -876,7 +892,11 @@ def fit_warp(CSRMatrix item_features,
 
                     # Sample again if the sample negative is actually a positive
                     if in_positives(negative_item_id, user_id, interactions):
-                        continue
+                      if ordered:
+                        # Sample again if the sample negative is actually better than our positive
+                        negative_true = interactions.get_entry(user_id, negative_item_id)
+                        if negative_true >= positive_true:
+                          continue
 
                     loss = weight * log(floor((item_features.rows - 1) / sampled))
 

--- a/lightfm/_lightfm_fast.pyx.template
+++ b/lightfm/_lightfm_fast.pyx.template
@@ -892,11 +892,14 @@ def fit_warp(CSRMatrix item_features,
 
                     # Sample again if the sample negative is actually a positive
                     if in_positives(negative_item_id, user_id, interactions):
-                      if ordered:
-                        # Sample again if the sample negative is actually better than our positive
-                        negative_true = interactions.get_entry(user_id, negative_item_id)
-                        if negative_true >= positive_true:
-                          continue
+                        if ordered:
+                            # Allow negative_items from interaction items 
+                            # only if they are ordinally lower than our positive_item
+                            negative_true = interactions.get_entry(user_id, negative_item_id)
+                            if negative_true >= positive_true:
+                                continue
+                        else:
+                            continue
 
                     loss = weight * log(floor((item_features.rows - 1) / sampled))
 
@@ -944,7 +947,8 @@ def fit_warp_kos(CSRMatrix item_features,
                  int k,
                  int n,
                  int num_threads,
-                 random_state):
+                 random_state,
+                 bint ordered=False):
     """
     Fit the model using the WARP loss.
     """
@@ -953,6 +957,7 @@ def fit_warp_kos(CSRMatrix item_features,
     cdef int negative_item_id, sampled, row, sampled_positive_item_id
     cdef int user_pids_start, user_pids_stop, no_positives, POS_SAMPLES
     cdef double positive_prediction, negative_prediction
+    cdef flt positive_true, negative_true
     cdef double loss, MAX_LOSS, sampled_positive_prediction
     cdef flt *user_repr
     cdef flt *pos_it_repr
@@ -1030,6 +1035,8 @@ def fit_warp_kos(CSRMatrix item_features,
                                    lightfm.item_scale,
                                    pos_it_repr)
 
+            positive_true = data.get_entry(user_id, positive_item_id)
+
             # Move on to the WARP step
             sampled = 0
 
@@ -1053,8 +1060,16 @@ def fit_warp_kos(CSRMatrix item_features,
 
                 if negative_prediction > positive_prediction - 1:
 
+                    # Sample again if the sample negative is actually a positive
                     if in_positives(negative_item_id, user_id, data):
-                        continue
+                        if ordered:
+                            # Allow negative_items from interaction items 
+                            # only if they are ordinally lower than our positive_item
+                            negative_true = data.get_entry(user_id, negative_item_id)
+                            if negative_true >= positive_true:
+                                continue
+                        else:
+                            continue
 
                     loss = log(floor((item_features.rows - 1) / sampled))
 
@@ -1104,7 +1119,8 @@ def fit_bpr(CSRMatrix item_features,
             double item_alpha,
             double user_alpha,
             int num_threads,
-            random_state):
+            random_state,
+            bint ordered=False):
     """
     Fit the model using the BPR loss.
     """
@@ -1112,6 +1128,7 @@ def fit_bpr(CSRMatrix item_features,
     cdef int i, j, no_examples, user_id, positive_item_id
     cdef int negative_item_id, sampled, row
     cdef double positive_prediction, negative_prediction
+    cdef flt positive_true, negative_true
     cdef flt weight
     cdef unsigned int[::1] random_states
     cdef flt *user_repr
@@ -1139,12 +1156,20 @@ def fit_bpr(CSRMatrix item_features,
             weight = sample_weight[row]
             user_id = user_ids[row]
             positive_item_id = item_ids[row]
+            positive_true = interactions.get_entry(user_id, positive_item_id)
 
             for j in range(no_examples):
                 negative_item_id = item_ids[(rand_r(&random_states[{thread_num}])
                                              % no_examples)]
                 if not in_positives(negative_item_id, user_id, interactions):
                     break
+                else:
+                    if ordered:
+                        # Allow negative_items from interaction items 
+                        # only if they are ordinally lower than our positive_item
+                        negative_true = interactions.get_entry(user_id, negative_item_id)
+                        if negative_true < positive_true:
+                            break
 
             compute_representation(user_features,
                                    lightfm.user_features,
@@ -1321,6 +1346,8 @@ def predict_ranks(CSRMatrix item_features,
             for item_id in range(test_interactions.cols):
 
                 if in_positives(item_id, user_id, train_interactions):
+                    # TODO: something could be done here if using ordinal interactions 
+                    # This depends on how we want to evaluate (so it's not necessary)
                     continue
 
                 compute_representation(item_features,

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -539,7 +539,8 @@ class LightFM(object):
                     self.item_alpha,
                     self.user_alpha,
                     num_threads,
-                    self.random_state)
+                    self.random_state,
+                    ordered)
         elif loss == 'warp-kos':
             fit_warp_kos(CSRMatrix(item_features),
                          CSRMatrix(user_features),
@@ -553,7 +554,8 @@ class LightFM(object):
                          self.k,
                          self.n,
                          num_threads,
-                         self.random_state)
+                         self.random_state,
+                         ordered)
         else:
             fit_logistic(CSRMatrix(item_features),
                          CSRMatrix(user_features),

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -332,7 +332,8 @@ class LightFM(object):
     def fit(self, interactions,
             user_features=None, item_features=None,
             sample_weight=None,
-            epochs=1, num_threads=1, verbose=False):
+            epochs=1, ordered=False,
+            num_threads=1, verbose=False):
         """
         Fit the model.
 
@@ -358,6 +359,8 @@ class LightFM(object):
              Not implemented for the k-OS loss.
         epochs: int, optional
              number of epochs to run
+        ordered: bool, optional
+            Whether or not to consider the entries of the interaction matrix ordered
         num_threads: int, optional
              Number of parallel computation threads to use. Should
              not be higher than the number of physical cores.
@@ -380,13 +383,15 @@ class LightFM(object):
                                 item_features=item_features,
                                 sample_weight=sample_weight,
                                 epochs=epochs,
+                                ordered=ordered,
                                 num_threads=num_threads,
                                 verbose=verbose)
 
     def fit_partial(self, interactions,
                     user_features=None, item_features=None,
                     sample_weight=None,
-                    epochs=1, num_threads=1, verbose=False):
+                    epochs=1, ordered=False,
+                    num_threads=1, verbose=False):
         """
         Fit the model.
 
@@ -415,6 +420,8 @@ class LightFM(object):
              Not implemented for the k-OS loss.
         epochs: int, optional
              number of epochs to run
+        ordered: bool, optional
+            Whether or not to consider the entries of the interaction matrix ordered
         num_threads: int, optional
              Number of parallel computation threads to use. Should
              not be higher than the number of physical cores.
@@ -477,14 +484,15 @@ class LightFM(object):
                             interactions,
                             sample_weight_data,
                             num_threads,
-                            self.loss)
+                            self.loss,
+                            ordered)
 
             self._check_finite()
 
         return self
 
     def _run_epoch(self, item_features, user_features, interactions,
-                   sample_weight, num_threads, loss):
+                   sample_weight, num_threads, loss, ordered):
         """
         Run an individual epoch.
         """
@@ -515,7 +523,8 @@ class LightFM(object):
                      self.item_alpha,
                      self.user_alpha,
                      num_threads,
-                     self.random_state)
+                     self.random_state,
+                     ordered)
         elif loss == 'bpr':
             fit_bpr(CSRMatrix(item_features),
                     CSRMatrix(user_features),


### PR DESCRIPTION
Update negative sampling to allow for negative items to be grabbed from positive examples only if it makes ordinal sense. (for BPR, WARP, and WARP-kOS loss)